### PR TITLE
Added instructions to build slurp from bundle file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ THP Book Updates:
 
 - Slurp (https://github.com/bbb31/slurp.git) github repo has been removed by the owner.  This tool can still be found on the THP Kali VM under /opt/slurp or on archive.org https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32.
 The instructions to build Slurp correctly are (tested in Kali):
-0. apt get install golang 
-1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
-2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
-3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
-4. mv slurp/vendor slurp/src
-5. export GOPATH=PATH/TO/slurp
-6. go build
+    0. apt get install golang 
+    1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
+    2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
+    3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
+    4. mv slurp/vendor slurp/src
+    5. export GOPATH=PATH/TO/slurp
+    6. go build
 
 - Bit.ly link for the Red Canary Windows ATT&CK Matrix is broken.  The new link is https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/windows-matrix.md.  
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ THP Book Updates:
 
 - Slurp (https://github.com/bbb31/slurp.git) github repo has been removed by the owner.  This tool can still be found on the THP Kali VM under /opt/slurp or on archive.org https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32.
 The instructions to build Slurp correctly are (tested in Kali):
-0. apt get install golang 
-1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
-2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
-3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
-4. mv slurp/vendor slurp/src
-5. export GOPATH=PATH/TO/slurp
-6. go build
+  0. apt get install golang 
+  1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
+  2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
+  3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
+  4. mv slurp/vendor slurp/src
+  5. export GOPATH=PATH/TO/slurp
+  6. go build
 
 - Bit.ly link for the Red Canary Windows ATT&CK Matrix is broken.  The new link is https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/windows-matrix.md.  
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The instructions to build Slurp correctly are (tested in Kali):
   4. mv slurp/vendor slurp/src
   5. export GOPATH=PATH/TO/slurp
   6. go build
+  7. ./slurp domain --domain cyberspacekittens.com
 
 - Bit.ly link for the Red Canary Windows ATT&CK Matrix is broken.  The new link is https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/windows-matrix.md.  
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ THP Book Updates:
 - Minor typo on the URL for the notes for the Custom Support System VM Web Lab.  Instead of blog it was supposed to be blob.  Updated link: https://github.com/cheetz/THP-ChatSupportSystem/blob/master/lab.txt.  I believe you should be able to update any ebooks copies on Kindle to contain the new link, but of course not physical.  Updated physical for future purchases.
 
 - Slurp (https://github.com/bbb31/slurp.git) github repo has been removed by the owner.  This tool can still be found on the THP Kali VM under /opt/slurp or on archive.org https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32.
+The instructions to build Slurp correctly are (tested in Kali):
+0. apt get install golang 
+1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
+2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
+3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
+4. mv slurp/vendor slurp/src
+5. export GOPATH=PATH/TO/slurp
+6. go build
 
 - Bit.ly link for the Red Canary Windows ATT&CK Matrix is broken.  The new link is https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/windows-matrix.md.  
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ THP Book Updates:
 
 - Slurp (https://github.com/bbb31/slurp.git) github repo has been removed by the owner.  This tool can still be found on the THP Kali VM under /opt/slurp or on archive.org https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32.
 The instructions to build Slurp correctly are (tested in Kali):
-    0. apt get install golang 
-    1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
-    2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
-    3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
-    4. mv slurp/vendor slurp/src
-    5. export GOPATH=PATH/TO/slurp
-    6. go build
+0. apt get install golang 
+1. wget https://archive.org/details/github.com-bbb31-slurp_-_2017-12-05_23-19-32
+2. git clone bbb31-slurp_-_2017-12-05_23-19-32.bundle
+3. mv bbb31-slurp_-_2017-12-05_23-19-32 slurp
+4. mv slurp/vendor slurp/src
+5. export GOPATH=PATH/TO/slurp
+6. go build
 
 - Bit.ly link for the Red Canary Windows ATT&CK Matrix is broken.  The new link is https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/windows-matrix.md.  
 


### PR DESCRIPTION
I had problems building slurp correctly in Kali Linux. 